### PR TITLE
Always attach a TelemetryDeck SDK instance to window

### DIFF
--- a/src/telemetrydeck.mjs
+++ b/src/telemetrydeck.mjs
@@ -91,8 +91,14 @@ export class TelemetryDeck {
   }
 }
 
-if (window && window.td) {
+// Automatically attach a TelemetryDeck instance to the window object once the SDK loads
+if (window) {
   const td = new TelemetryDeck({});
-  td.ingest(window.td);
+
+  // Ingest messages which where pushed to an array on the window object
+  if (window.td) {
+    td.ingest(window.td);
+  }
+
   window.td = td;
 }

--- a/src/telemetrydeck.mjs
+++ b/src/telemetrydeck.mjs
@@ -1,7 +1,7 @@
 import { version } from '../package.json';
-import sha256 from './utils/sha256.mjs';
-import assertKeyValue from './utils/assert-key-value.mjs';
-import transformPayload from './utils/transform-payload.mjs';
+import { sha256 } from './utils/sha256.mjs';
+import { assertKeyValue } from './utils/assert-key-value.mjs';
+import { transformPayload } from './utils/transform-payload.mjs';
 
 const APP = 'app';
 const USER = 'user';

--- a/src/utils/assert-key-value.mjs
+++ b/src/utils/assert-key-value.mjs
@@ -1,7 +1,5 @@
-const assertKeyValue = (key, value) => {
+export const assertKeyValue = (key, value) => {
   if (!value) {
     throw new Error(`TelemetryDeck: "${key}" is not set`);
   }
 };
-
-export default assertKeyValue;

--- a/src/utils/sha256.mjs
+++ b/src/utils/sha256.mjs
@@ -1,5 +1,5 @@
 // https://stackoverflow.com/a/48161723/54547
-export default async function sha256(message) {
+export async function sha256(message) {
   // encode as UTF-8
   const messageBuffer = new TextEncoder().encode(message);
 

--- a/src/utils/transform-payload.mjs
+++ b/src/utils/transform-payload.mjs
@@ -1,3 +1,2 @@
-const transformPayload = (payload) => Object.entries(payload).map((entry) => entry.join(':'));
-
-export default transformPayload;
+export const transformPayload = (payload) =>
+  Object.entries(payload).map((entry) => entry.join(':'));


### PR DESCRIPTION
The previous behavior lead to a bug uncovered in #5: The SDK was only attached to `window.td` if the latter was already defined, which is not the case if `window.td` is defined in a deferred script. 

We have no automatic tests for this behavior at the moment as Jest wouldn't allow us to do so. We should probably introduce some e2e testing solution like [Playwright](https://playwright.dev) or [Cypress](https://www.cypress.io) in the future.