### PR TITLE
"window" is not available during Server-Side Rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ You can optionally attach an object with string values to the signal. This will 
 
 ### 📚 Full Docs
 
-Go to [docs.telemetrydeck.com](https://docs.telemetrydeck.com) to see all documentation articles
+Go to [telemetrydeck.com/docs](https://telemetrydeck.com/docs) to see all documentation articles

--- a/src/telemetrydeck.mjs
+++ b/src/telemetrydeck.mjs
@@ -92,7 +92,7 @@ export class TelemetryDeck {
 }
 
 // Automatically attach a TelemetryDeck instance to the window object once the SDK loads
-if (window) {
+if (typeof window !== 'undefined') {
   const td = new TelemetryDeck({});
 
   // Ingest messages which where pushed to an array on the window object


### PR DESCRIPTION
I've added TelemetryDeck to my GatsbyJS site and I've got an error. I think it happens this the browser doesn’t exist during the build time. 

With the proposed change I've managed to fix the issue and the build was completed successfully.

```
"window" is not available during Server-Side Rendering. Enable "DEV_SSR" to debug this during "gatsby develop".

See our docs page for more info on this error: https://gatsby.dev/debug-html


  119 |
  120 | // Automatically attach a TelemetryDeck instance to the window object once the SDK loads
> 121 | if (window) {
      | ^
  122 |   const td = new TelemetryDeck({});
  123 |
  124 |   // Ingest messages which where pushed to an array on the window object


  WebpackError: ReferenceError: window is not defined

  - telemetrydeck.mjs:121
    [michalslepko.dev]/[@telemetrydeck]/sdk/dist/telemetrydeck.mjs:121:1
```