### PR TITLE
Add types to package.json and typedef for payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Send analytics signals to TelemetryDeck",
   "main": "dist/telemetrydeck.cjs",
   "module": "dist/telemetrydeck.js",
+  "types": "dist/telemetrydeck.d.ts",
   "files": [
     "dist/*",
     "README.md",

--- a/src/telemetrydeck.js
+++ b/src/telemetrydeck.js
@@ -16,6 +16,10 @@ import { version } from './utils/version.js';
  * @property {Function} [subtleCrypto] Used for providing an alternative implementation of SubtleCrypto where no browser is available. Expects a class providing a `.digest(method, value)` method.
  */
 
+/**
+ * @typedef {Object.<string, any>} TelemetryDeckPayload
+ */
+
 export default class TelemetryDeck {
   appID = '';
   clientUser = '';


### PR DESCRIPTION
### Problem
I had two problems when integrating the SDK into telemetrydeck-react. First, the `d.ts` file wasn't recognized by typescript, so I added the file manually to the types field of the `package.json`. After doing so, I noticed that the `TelemetryDeckPayload` type was missing. 

### What I did
I basically added the `types` field to your `package.json` referencing the `telemetrydeck.d.ts` that is generated and added a very basic typedef of the `TelemetryDeckPayload` type.
I also ran the `prepublish` command to test that my work was correct and saw the right payload type exported from the `d.ts` file.

```ts
export type TelemetryDeckPayload = {
    [x: string]: any;
};
```