### PR TITLE
Refactor deprecated prepublish to prepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:js:fix": "eslint . --fix",
     "lint:md": "prettier --check \"**/*.{html,md,yaml,yml}\"",
     "lint:md:fix": "prettier --write \"**/*.{html,md,yaml,yml}\"",
-    "prepublish": "rollup -c && tsc dist/*.js --declaration --allowJs --emitDeclarationOnly",
+    "prepack": "rollup -c && tsc dist/*.js --declaration --allowJs --emitDeclarationOnly",
     "release": "dotenv release-it --",
     "test": "ava",
     "test:watch": "ava --watch"


### PR DESCRIPTION
### Problem
It seemed that my last change wasn't published, so I thought that the `prepublish` script didn't run before the publish of the last package. I did some research together with @pichfl and found out the `prebublish` lifecycle  is deprecated and does not run before `publish` but after `install` or `ci`. 

### What I changed

After a quick chat with @pichfl we agreed that the `prepack` lifecycle hook (another option would be `prepublishOnly`) should do the magic (cf. [npm docs](https://docs.npmjs.com/cli/v10/using-npm/scripts#life-cycle-scripts)), so I changed the script from prepublish to prepack. 
 